### PR TITLE
Better parsing of "end of line"

### DIFF
--- a/pyecsca/ec/coordinates.py
+++ b/pyecsca/ec/coordinates.py
@@ -96,9 +96,8 @@ class EFDCoordinateModel(CoordinateModel):
 
     def __read_coordinates_file(self, file_path):
         with resource_stream(__name__, file_path) as f:
-            line = f.readline().decode("ascii")
+            line = f.readline().decode("ascii").rstrip()
             while line:
-                line = line[:-1]
                 if line.startswith("name"):
                     self.full_name = line[5:]
                 elif line.startswith("variable"):
@@ -120,7 +119,7 @@ class EFDCoordinateModel(CoordinateModel):
                 elif line.startswith("assume"):
                     self.assumptions.append(
                             parse(line[7:].replace("^", "**"), mode="exec"))
-                line = f.readline().decode("ascii")
+                line = f.readline().decode("ascii").rstrip()
 
     def __eq__(self, other):
         if not isinstance(other, EFDCoordinateModel):

--- a/pyecsca/ec/formula.py
+++ b/pyecsca/ec/formula.py
@@ -305,9 +305,8 @@ class EFDFormula(Formula):
 
     def __read_meta_file(self, path):
         with resource_stream(__name__, path) as f:
-            line = f.readline().decode("ascii")
+            line = f.readline().decode("ascii").rstrip()
             while line:
-                line = line[:-1]
                 if line.startswith("source"):
                     self.meta["source"] = line[7:]
                 elif line.startswith("parameter"):
@@ -317,7 +316,7 @@ class EFDFormula(Formula):
                         parse(line[7:].replace("=", "==").replace("^", "**"), mode="eval"))
                 elif line.startswith("unified"):
                     self.unified = True
-                line = f.readline().decode("ascii")
+                line = f.readline().decode("ascii").rstrip()
 
     def __read_op3_file(self, path):
         with resource_stream(__name__, path) as f:

--- a/pyecsca/ec/model.py
+++ b/pyecsca/ec/model.py
@@ -66,7 +66,7 @@ class EFDCurveModel(CurveModel):
         with resource_stream(__name__, file_path) as f:
             line = f.readline()
             while line:
-                line = line.decode("ascii")[:-1]
+                line = line.decode("ascii").rstrip()
                 if line.startswith("name"):
                     cls.name = line[5:]
                 elif line.startswith("parameter"):


### PR DESCRIPTION
Using .rstrip() multi-byte end of line (CRLF on Windows) is correctly stripped

This correct a bug when using pyecsca on Windows where variables are badly parsed (resulting in "X\r" instead of "X")