### PR TITLE
Fix import error in test_target.py

### DIFF
--- a/test/sca/test_target.py
+++ b/test/sca/test_target.py
@@ -5,7 +5,6 @@ from copy import copy
 import pytest
 from importlib_resources import files, as_file
 
-from smartcard.pcsc.PCSCExceptions import BaseSCardException
 import test.data.sca
 from pyecsca.ec.key_agreement import ECDH_SHA1
 from pyecsca.ec.key_generation import KeyGeneration
@@ -88,6 +87,7 @@ def target():
     if not has_pyscard:
         pytest.skip("No pyscard.")
     from smartcard.System import readers
+    from smartcard.pcsc.PCSCExceptions import BaseSCardException
     rs = None
     try:
         rs = readers()


### PR DESCRIPTION
An exception import at the beginning of the file caused errors in test discovery. Moved the import to where it's used after the condition checking if the module containing it is installed.